### PR TITLE
Migrate commands/events into payload to enable more generic message passing

### DIFF
--- a/proto/relay.proto
+++ b/proto/relay.proto
@@ -9,15 +9,33 @@ import "self_serve/orb.proto";
 
 // Service Definitions
 service OrbService {
-  rpc OrbConnect(stream OrbEvent) returns (stream OrbCommand);
+  rpc OrbConnect(stream RelayMessage) returns (stream RelayMessage);
 }
 
 service AppService {
-  rpc AppConnect(stream AppEvent) returns (stream AppCommand);
+  rpc AppConnect(stream RelayMessage) returns (stream RelayMessage);
 }
 
 service BackendService {
   rpc RequestOrbUpdateConfig(config.OrbUpdateConfigRequest) returns (config.OrbUpdateConfigResponse);
+}
+
+message RelayPayload {
+  oneof payload {
+    OrbConnectRequestEvent orb_connect_request_event = 1;
+    AppConnectRequestEvent app_connect_request_event = 2;
+    OrbCommand orb_command = 3;
+    OrbEvent orb_event = 4;
+    AppCommand app_command = 5;
+    AppEvent app_event = 6;
+    BackendEvent backend_event = 7;
+    BackendCommand backend_command = 8;
+  }
+}
+
+message RelayMessage {
+  string destination = 1;
+  RelayPayload payload = 2;
 }
 
 message OrbConnectRequestEvent {

--- a/proto/self_serve/app.proto
+++ b/proto/self_serve/app.proto
@@ -6,9 +6,7 @@ message AppReceiveQRCommand {
   string qr_code = 1;
 }
 
-message AppConnectedToOrbCommand {
-  string orb_id = 1;
-}
+message AppConnectedToOrbCommand {}
 
 message AppShowStartSignupButtonCommand {}
 
@@ -20,6 +18,4 @@ message AppReceiveSignupResultCommand {
 
 message AppRequestStartSelfServeFlowEvent {}
 
-message AppRequestStartSignupEvent {
-  string orb_id = 1;
-}
+message AppRequestStartSignupEvent {}

--- a/proto/self_serve/orb.proto
+++ b/proto/self_serve/orb.proto
@@ -4,15 +4,10 @@ package selfserve;
 
 message OrbStartSelfServeSignupCommand {}
 
-message OrbSelfServeSessionStartedEvent {
-  string app_id = 1;
-}
+message OrbSelfServeSessionStartedEvent {}
 
-message OrbSignupStartedEvent {
-  string app_id = 1;
-}
+message OrbSignupStartedEvent {}
 
 message OrbSignupCompletedEvent {
-  string app_id = 1;
-  bool success = 2;
+  bool success = 1;
 }


### PR DESCRIPTION
This change modifies existing message format to migrate commands/events into a payload section and utilize destination header in root of RelayMessage. This allows us to be more generic with respect to our software architecture, and pass relay messages around which can be inspected for payload. We can also utilize the default destination field present in all orb-relay messages to enable new application behaviors that do not require dedicated handlers in the service. 