### PR TITLE
Make Tonic optional

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "rust-analyzer.check.features": "all",
+    "rust-analyzer.cargo.features": "all",
+    "rust-analyzer.check.command": "clippy"
+}

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,10 +9,11 @@ rust-version.workspace = true
 [features]
 client = []
 server = []
+local_codegen = ["tonic"]
 
 [dependencies]
 prost = "0.13.2"
-tonic = "0.12.2"
+tonic = { version = "0.12.2", optional = true }
 
 [build-dependencies]
 tonic-build = "0.12.2"


### PR DESCRIPTION
Dependent projects should provide their own tonic implementation and version. With this optional dep now there will be no problem of using newer tonic versions outside the crate and older ones inside.