### PR TITLE
Modify app connect request to support ZKP auth in addition to static token auth

### DIFF
--- a/proto/relay.proto
+++ b/proto/relay.proto
@@ -44,8 +44,8 @@ message OrbConnectRequest {
 
 message AppConnectRequest {
   string app_id = 1;
-  oneof body {
-    string auth_token = 2;
+  oneof auth_method {
+    string token = 2;
     ZkpAuthRequest zkp_auth_request = 3;
   }
 }

--- a/proto/relay.proto
+++ b/proto/relay.proto
@@ -44,7 +44,17 @@ message OrbConnectRequest {
 
 message AppConnectRequest {
   string app_id = 1;
-  string auth_token = 2;
+  oneof body {
+    string auth_token = 2;
+    ZkpAuthRequest zkp_auth_request = 3;
+  }
+}
+
+message ZkpAuthRequest {
+  string root = 1;
+  string signal = 2;
+  string nullifier_hash = 3;
+  string proof = 4;
 }
 
 message ConnectResponse {


### PR DESCRIPTION
We need to allow additional parameters in the call to authenticate apps. This PR maintains support for the existing static token auth for testing while introducing the new ZKP format. 