### PR TITLE
Add new RPC service to eventually replace existing separated client services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,6 +526,7 @@ name = "orb-relay-messages"
 version = "0.0.0"
 dependencies = [
  "prost",
+ "prost-types",
  "tonic",
  "tonic-build",
 ]
@@ -608,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2ecbe40f08db5c006b5764a2645f7f3f141ce756412ac9e1dd6087e6d32995"
+checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -639,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf0c195eebb4af52c752bec4f52f645da98b6e92077a04110c7f349477ae5ac"
+checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
  "itertools",
@@ -652,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60caa6738c7369b940c3d49246a8d1749323674c65cb13010134f5c9bad5b519"
+checksum = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670"
 dependencies = [
  "prost",
 ]

--- a/proto/relay.proto
+++ b/proto/relay.proto
@@ -2,10 +2,9 @@ syntax = "proto3";
 
 package relay;
 
-import "google/protobuf/any.proto";
-
 import "config/backend.proto";
 import "config/orb.proto";
+import "google/protobuf/any.proto";
 import "self_serve/app/v1/app.proto";
 import "self_serve/orb/v1/orb.proto";
 

--- a/proto/relay.proto
+++ b/proto/relay.proto
@@ -20,7 +20,7 @@ message Entity {
 }
 
 service RelayService {
-  rpc Connect(stream RelayMessage) returns (stream RelayMessage);
+  rpc EstablishConnection(stream RelayMessage) returns (stream RelayMessage);
 }
 
 service OrbService {

--- a/proto/relay.proto
+++ b/proto/relay.proto
@@ -21,7 +21,7 @@ message Entity {
 }
 
 service RelayService {
-  rpc Connect(stream RelayMessage) returns (stream RelayMessage);
+  rpc RelayConnect(stream RelayMessage) returns (stream RelayMessage);
 }
 
 service OrbService {

--- a/proto/relay.proto
+++ b/proto/relay.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package relay;
 
+import "google/protobuf/any.proto";
+
 import "config/backend.proto";
 import "config/orb.proto";
 import "self_serve/app/v1/app.proto";
@@ -20,7 +22,7 @@ message Entity {
 }
 
 service RelayService {
-  rpc EstablishConnection(stream RelayMessage) returns (stream RelayMessage);
+  rpc RelayConnect(stream RelayMessage) returns (stream RelayMessage);
 }
 
 service OrbService {
@@ -113,5 +115,8 @@ message RelayPayload {
     self_serve.orb.v1.NoState no_state = 17;
 
     Ack ack = 18;
+
+    ConnectRequest connect_request = 19;
+    google.protobuf.Any any_payload = 20;
   }
 }

--- a/proto/relay.proto
+++ b/proto/relay.proto
@@ -19,6 +19,10 @@ message Entity {
   EntityType entity_type = 2;
 }
 
+service RelayService {
+  rpc Connect(stream RelayMessage) returns (stream RelayMessage);
+}
+
 service OrbService {
   rpc OrbConnect(stream RelayMessage) returns (stream RelayMessage);
 }
@@ -40,6 +44,14 @@ message RelayMessage {
 
 message Ack {
   uint64 seq = 1;
+}
+
+message ConnectRequest {
+  string client_id = 1;
+  oneof auth_method {
+    string token = 2;
+    ZkpAuthRequest zkp_auth_request = 3;
+  }
 }
 
 message OrbConnectRequest {

--- a/proto/relay.proto
+++ b/proto/relay.proto
@@ -22,7 +22,7 @@ message Entity {
 }
 
 service RelayService {
-  rpc RelayConnect(stream RelayMessage) returns (stream RelayMessage);
+  rpc Connect(stream RelayMessage) returns (stream RelayMessage);
 }
 
 service OrbService {
@@ -48,7 +48,7 @@ message Ack {
   uint64 seq = 1;
 }
 
-message ConnectRequest {
+message EstablishConnectionRequest {
   string client_id = 1;
   oneof auth_method {
     string token = 2;
@@ -116,7 +116,7 @@ message RelayPayload {
 
     Ack ack = 18;
 
-    ConnectRequest connect_request = 19;
+    EstablishConnectionRequest connect_request = 19;
     google.protobuf.Any any_payload = 20;
   }
 }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "orb-relay-messages"
-version = "0.0.0"
-edition.workspace = true
-license.workspace = true
-repository.workspace = true
+name                   = "orb-relay-messages"
+version                = "0.0.0"
+edition.workspace      = true
+license.workspace      = true
+repository.workspace   = true
 rust-version.workspace = true
 
 [features]
@@ -11,8 +11,9 @@ client = []
 server = []
 
 [dependencies]
-prost = "0.13.2"
-tonic = "0.12.2"
+prost       = "0.13.2"
+prost-types = "0.13.3"
+tonic       = "0.12.2"
 
 [build-dependencies]
 tonic-build = "0.12.2"


### PR DESCRIPTION
I would like to eliminate our separate RPC services and use a consolidated RPC service endpoint for all clients. This PR sets up the messaging framework for it, and once support is added in the relay service, we can start migrating off of old endpoints and eventually deprecate them entirely