### PR TITLE
Added timestamp fields to Ping/Pong messages

### DIFF
--- a/proto/relay.proto
+++ b/proto/relay.proto
@@ -34,8 +34,7 @@ service AppService {
 }
 
 service BackendService {
-  rpc RequestOrbUpdateConfig(config.OrbUpdateConfigRequest)
-      returns (config.OrbUpdateConfigResponse);
+  rpc RequestOrbUpdateConfig(config.OrbUpdateConfigRequest) returns (config.OrbUpdateConfigResponse);
 }
 
 message RelayMessage {
@@ -111,8 +110,7 @@ message RelayPayload {
     self_serve.orb.v1.CaptureStarted capture_started = 11;
     self_serve.orb.v1.CaptureEnded capture_ended = 12;
     self_serve.orb.v1.SignupEnded signup_ended = 13;
-    self_serve.orb.v1.AgeVerificationRequiredFromOperator
-        age_verification_required_from_operator = 14;
+    self_serve.orb.v1.AgeVerificationRequiredFromOperator age_verification_required_from_operator = 14;
     self_serve.app.v1.StartCapture start_capture = 15;
     self_serve.app.v1.RequestState request_state = 16;
     self_serve.orb.v1.SelfServeStatus self_serve_status = 17;

--- a/proto/relay.proto
+++ b/proto/relay.proto
@@ -44,7 +44,9 @@ message RelayMessage {
   uint64 seq = 4;
 }
 
-message Ack { uint64 seq = 1; }
+message Ack {
+  uint64 seq = 1;
+}
 
 message EstablishConnectionRequest {
   string client_id = 1;

--- a/proto/relay.proto
+++ b/proto/relay.proto
@@ -83,13 +83,13 @@ message ConnectResponse {
 }
 
 message Ping {
-  optional string id = 1;
-  optional google.protobuf.Timestamp timestamp = 2;
+  string id = 1;
+  google.protobuf.Timestamp timestamp = 2;
 }
 
 message Pong {
-  optional string id = 1;
-  optional google.protobuf.Timestamp ping_timestamp = 2;
+  string id = 1;
+  google.protobuf.Timestamp ping_timestamp = 2;
 }
 
 message RelayPayload {

--- a/proto/relay.proto
+++ b/proto/relay.proto
@@ -89,7 +89,8 @@ message Ping {
 
 message Pong {
   string id = 1;
-  google.protobuf.Timestamp ping_timestamp = 2;
+  google.protobuf.Timestamp timestamp = 2;
+  google.protobuf.Timestamp ping_timestamp = 3;
 }
 
 message RelayPayload {

--- a/proto/relay.proto
+++ b/proto/relay.proto
@@ -5,6 +5,7 @@ package relay;
 import "config/backend.proto";
 import "config/orb.proto";
 import "google/protobuf/any.proto";
+import "google/protobuf/timestamp.proto";
 import "self_serve/app/v1/app.proto";
 import "self_serve/orb/v1/orb.proto";
 
@@ -33,7 +34,8 @@ service AppService {
 }
 
 service BackendService {
-  rpc RequestOrbUpdateConfig(config.OrbUpdateConfigRequest) returns (config.OrbUpdateConfigResponse);
+  rpc RequestOrbUpdateConfig(config.OrbUpdateConfigRequest)
+      returns (config.OrbUpdateConfigResponse);
 }
 
 message RelayMessage {
@@ -43,9 +45,7 @@ message RelayMessage {
   uint64 seq = 4;
 }
 
-message Ack {
-  uint64 seq = 1;
-}
+message Ack { uint64 seq = 1; }
 
 message EstablishConnectionRequest {
   string client_id = 1;
@@ -83,10 +83,12 @@ message ConnectResponse {
 
 message Ping {
   optional string id = 1;
+  optional google.protobuf.Timestamp timestamp = 2;
 }
 
 message Pong {
   optional string id = 1;
+  optional google.protobuf.Timestamp ping_timestamp = 2;
 }
 
 message RelayPayload {
@@ -109,7 +111,8 @@ message RelayPayload {
     self_serve.orb.v1.CaptureStarted capture_started = 11;
     self_serve.orb.v1.CaptureEnded capture_ended = 12;
     self_serve.orb.v1.SignupEnded signup_ended = 13;
-    self_serve.orb.v1.AgeVerificationRequiredFromOperator age_verification_required_from_operator = 14;
+    self_serve.orb.v1.AgeVerificationRequiredFromOperator
+        age_verification_required_from_operator = 14;
     self_serve.app.v1.StartCapture start_capture = 15;
     self_serve.app.v1.RequestState request_state = 16;
     self_serve.orb.v1.SelfServeStatus self_serve_status = 17;


### PR DESCRIPTION
- Added `timestamp` field to `Ping` message
- Added `ping_timestamp` field to `Pong` message
  - (to reflect the ping timestamp back)

This is in preparation for a Canary implementation which uses Ping/Pong message to measure latency throughout our Relay deployments