### PR TITLE
versioning idea

### DIFF
--- a/proto/self_serve/app/self_serve.proto
+++ b/proto/self_serve/app/self_serve.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package self_serve.app;
+
+message AppSelfServeModeMessage {
+  oneof message {
+    StartCapture start_capture = 1;
+    RequestState request_state = 2;
+  }
+}
+
+message StartCapture {}
+message RequestState {}

--- a/proto/self_serve/app/v1/app.proto
+++ b/proto/self_serve/app/v1/app.proto
@@ -1,6 +1,0 @@
-syntax = "proto3";
-
-package self_serve.app.v1;
-
-message StartCapture {}
-message RequestState {}

--- a/proto/self_serve/orb/orb.proto
+++ b/proto/self_serve/orb/orb.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+package self_serve.orb;
+
+enum OrbMode {
+  ORB_MODE_UNSPECIFIED = 0;
+  LEGACY = 1;
+  SELF_SERVE = 2;
+}
+
+enum OrbType {
+  ORB_TYPE_UNSPECIFIED = 0;
+  PEARL = 1;
+  DIAMOND = 2;
+}
+
+message OrbMetadata {
+  string orb_id = 1;
+  OrbType orb_type = 2;
+  OrbMode orb_mode = 3;
+}

--- a/proto/self_serve/orb/self_serve.proto
+++ b/proto/self_serve/orb/self_serve.proto
@@ -1,27 +1,22 @@
 syntax = "proto3";
 
-package self_serve.orb.v1;
+package self_serve.orb;
 
-enum OrbMode {
-  ORB_MODE_UNSPECIFIED = 0;
-  LEGACY = 1;
-  SELF_SERVE = 2;
-}
-
-enum OrbType {
-  ORB_TYPE_UNSPECIFIED = 0;
-  PEARL = 1;
-  DIAMOND = 2;
+message OrbSelfServeModeMessage {
+  oneof message {
+    NoState no_state = 1;
+    SelfServeStatus self_serve_status = 2;
+    CaptureStarted capture_started = 3;
+    CaptureTriggerTimeout capture_trigger_timeout = 4;
+    CaptureEnded capture_ended = 5;
+    SignupEnded signup_ended = 6;
+    AgeVerificationRequiredFromOperator age_verification_required_from_operator = 7;
+  }
 }
 
 message NoState {}
 message SelfServeStatus {
   bool is_self_serve_enabled = 1;
-}
-message AnnounceOrbId {
-  string orb_id = 1;
-  OrbType orb_type = 2;
-  OrbMode orb_mode = 3;
 }
 message CaptureStarted {}
 message CaptureTriggerTimeout {}


### PR DESCRIPTION
```
enum OrbMode {
  ORB_MODE_UNSPECIFIED = 0;
  LEGACY = 1;
  SELF_SERVE = 2;
}

enum OrbType {
  ORB_TYPE_UNSPECIFIED = 0;
  PEARL = 1;
  DIAMOND = 2;
}

message OrbMetadata {
  string orb_id = 1;
  OrbType orb_type = 2;
  OrbMode orb_mode = 3;
}
```

* `OrbMetadata` is a replacement for `AnnouncingOrbId` message. 
* `OrbMetadata` is the first message Orb sends to the App. 
* App decides how to communicate with the Orb based on `OrbMetadata.orb_mode` field.
* Self Serve mode has all of its messages in `self_serve.proto` file. 

### Forward compatibility
If we decide to add a new mode, eg. `Self Serve v2`, we do this:
* Add new `SELF_SERVE_2` option in `OrbMode` enum
* Add new `self_serve_v2.proto` file with corresponding messages for this mode

If app doesn't support a mode it received, it would prompt user to update the app to verify.

### Backward compatibility
* We can add messages in `self_serve.proto` but only if they won't break the flow in old apps, every breaking change requires a new OrbMode
* We can only add fields to `OrbMetadata` message