### PR TITLE
Enable dependent crates to import protos

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,10 +5,12 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
+links = "orb_relay_messages"
 
 [features]
 client = []
 server = []
+
 
 [dependencies]
 prost = "0.13.3"

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -24,4 +24,6 @@ fn main() {
             &["./proto"],
         )
         .unwrap();
+
+    println!("cargo:proto_path={}", std::env::current_dir().unwrap().join("proto").display());
 }


### PR DESCRIPTION
Enables dependent crates to get the fully qualified path to the 'protos/' directory at build time.

By setting a 'links' attribute on our Cargo.toml package, Cargo makes 'println!("cargo:key=val")' visible to dependent crates at build time, using an environment variable with the format:

    DEP_<LINKS_VALUE>_<KEY>=<val>

We use this to set the DEP_ORB_RELAY_MESSAGES_PROTO_PATH to the path of the 'protos' directory