### PR TITLE
Add new job subscriber domain model to separate client domain from subscriber domain

### DIFF
--- a/proto/fleet_cmdr/fleet_cmdr.proto
+++ b/proto/fleet_cmdr/fleet_cmdr.proto
@@ -16,6 +16,7 @@ message JobExecution {
   string job_id = 1;
   string job_execution_id = 2;
   string job_document = 3;
+  bool should_cancel = 4;
 }
 
 message JobExecutionUpdate {

--- a/proto/fleet_cmdr/fleet_cmdr.proto
+++ b/proto/fleet_cmdr/fleet_cmdr.proto
@@ -4,7 +4,13 @@ package fleet_cmdr.v1;
 
 message JobNotify {}
 
-message JobRequestNext {}
+message JobRequestNext {
+  repeated string ignore_job_execution_ids = 1;
+}
+
+message JobCancel {
+  string job_execution_id = 1;
+}
 
 message JobExecution {
   string job_id = 1;
@@ -38,4 +44,5 @@ enum JobExecutionStatus {
   IN_PROGRESS = 2;
   SUCCEEDED = 3;
   FAILED = 4;
+  CANCELLED = 5;
 }

--- a/proto/fleet_cmdr/fleet_cmdr.proto
+++ b/proto/fleet_cmdr/fleet_cmdr.proto
@@ -25,10 +25,11 @@ message JobExecutionUpdate {
 message JobExecutionSubscriberUpdate {
   string job_id = 1;
   string job_execution_id = 2;
-  JobExecutionStatus status = 3;
-  string std_out = 4;
-  string std_err = 5;
-  optional string orb_id = 6;
+  string job_execution_subscriber_id = 3;
+  JobExecutionStatus status = 4;
+  string std_out = 5;
+  string std_err = 6;
+  optional string orb_id = 7;
 }
 
 enum JobExecutionStatus {

--- a/proto/fleet_cmdr/fleet_cmdr.proto
+++ b/proto/fleet_cmdr/fleet_cmdr.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package jobs.v1;
+package fleet_cmdr.v1;
 
 message JobNotify {}
 

--- a/proto/jobs/jobs.proto
+++ b/proto/jobs/jobs.proto
@@ -18,6 +18,16 @@ message JobExecutionUpdate {
   JobExecutionStatus status = 3;
   string std_out = 4;
   string std_err = 5;
+}
+
+// This is a separate message from JobExecutionUpdate to separate the domain of the job execution from the domain of the job execution subscriber.
+// The job service/worker will inject the orb_id into the JobExecutionSubscriberUpdate message.
+message JobExecutionSubscriberUpdate {
+  string job_id = 1;
+  string job_execution_id = 2;
+  JobExecutionStatus status = 3;
+  string std_out = 4;
+  string std_err = 5;
   optional string orb_id = 6;
 }
 

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -20,7 +20,7 @@ fn main() {
                 "./proto/self_serve/orb/v1/orb.proto",
                 "./proto/config/backend.proto",
                 "./proto/config/orb.proto",
-                "./proto/jobs/jobs.proto",
+                "./proto/fleet_cmdr/fleet_cmdr.proto",
             ],
             &["./proto", "/usr/local/include"],
         )

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -53,8 +53,8 @@ pub mod config {
     tonic::include_proto!("config");
 }
 
-pub mod jobs {
+pub mod fleet_cmdr {
     pub mod v1 {
-        tonic::include_proto!("jobs.v1");
+        tonic::include_proto!("fleet_cmdr.v1");
     }
 }


### PR DESCRIPTION
This pull request introduces changes to migrate job-related protocol buffer definitions from the `jobs` module to a new `fleet_cmdr` module. The migration involves updating the `.proto` files, modifying Rust module imports, and adjusting build configurations.

### Migration of job-related protocol buffers:

* [`proto/fleet_cmdr/fleet_cmdr.proto`](diffhunk://#diff-f49a2f39242a41c74ca1b9299eed36591e135ace8dc9d20cf0cd680b05577b28R1-R49): Added a new `.proto` file defining the `fleet_cmdr.v1` package, including messages (`JobNotify`, `JobRequestNext`, `JobCancel`, `JobExecution`, `JobExecutionUpdate`, `JobExecutionSubscriberUpdate`) and an enum (`JobExecutionStatus`) for job-related operations. This file replaces the previous `jobs.proto` file.

* [`proto/jobs/jobs.proto`](diffhunk://#diff-e34dee22c1e69bab67f264710b0d0245c906dd017965a8b0031aa932f3c4c3f3L1-L30): Removed the old `.proto` file for the `jobs.v1` package, which contained similar definitions for job-related operations.

### Rust module updates:

* [`rust/build.rs`](diffhunk://#diff-09d6225098e081c7aeeec88e45ce1bcd860bbc2aa6e6917decdcd6baf5e3080fL23-R23): Updated the build script to use the new `fleet_cmdr.proto` file instead of the removed `jobs.proto` file during protocol buffer compilation.

* [`rust/src/lib.rs`](diffhunk://#diff-f64796ccc388f201986ea7eaaf07bbefbd8ac1a56bb995fb505da80879872a39L56-R58): Renamed the Rust module `jobs` to `fleet_cmdr` and updated the `tonic::include_proto!` macro to reference the new `fleet_cmdr.v1` package.