### PR TITLE
Use jobs namespace instead of fleet cmdr

### DIFF
--- a/proto/jobs/jobs.proto
+++ b/proto/jobs/jobs.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package fleet_cmdr.v1;
+package jobs.v1;
 
 message JobNotify {}
 

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -20,7 +20,7 @@ fn main() {
                 "./proto/self_serve/orb/v1/orb.proto",
                 "./proto/config/backend.proto",
                 "./proto/config/orb.proto",
-                "./proto/fleet_cmdr/fleet_cmdr.proto",
+                "./proto/jobs/jobs.proto",
             ],
             &["./proto", "/usr/local/include"],
         )

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -53,8 +53,8 @@ pub mod config {
     tonic::include_proto!("config");
 }
 
-pub mod fleet_cmdr {
+pub mod jobs {
     pub mod v1 {
-        tonic::include_proto!("fleet_cmdr.v1");
+        tonic::include_proto!("jobs.v1");
     }
 }


### PR DESCRIPTION
We originally uses the name of fleet cmdr to refer to our jobs service/client, but now that we're using the Fleet Commander nomenclature to refer to an internal application, we need to update the naming for these messages and associated client to use Jobs.