### PR TITLE
Add FAILURE_UNSUPPORTED job status

### DIFF
--- a/proto/jobs/jobs.proto
+++ b/proto/jobs/jobs.proto
@@ -46,4 +46,5 @@ enum JobExecutionStatus {
   SUCCEEDED = 3;
   FAILED = 4;
   CANCELLED = 5;
+  FAILED_UNSUPPORTED = 6; // Indicates that the job execution failed because the job is not supported by the orb, likely due to an outdated jobs agent.
 }


### PR DESCRIPTION
This new job status will indicate to our backend that a device is unable to complete a job, specifically because the version of jobs agent on the device does not support the command.