### PR TITLE
Update orb relay messages

### DIFF
--- a/proto/common/v1/orb.proto
+++ b/proto/common/v1/orb.proto
@@ -46,6 +46,7 @@ message AnnounceOrbId {
   Selector selector = 6;
   bool heartbeat = 7;
   uint64 protocol_version = 8;
+  string signup_id = 9;
 }
 
 // Appointment metadata for verification purposes

--- a/proto/self_serve/orb/v1/orb.proto
+++ b/proto/self_serve/orb/v1/orb.proto
@@ -31,6 +31,7 @@ message UserDataFailure {
     INVALID_REQUEST_DATA = 2;
     BYPASS_AGE_TOKEN_INVALID = 3;
     UNKNOWN = 4;
+    USER_DATA_NOT_RECEIVED = 5;
   }
 
   ErrorType error_type = 1;


### PR DESCRIPTION
### Notes
* add `signup_id` as a response for announceOrbID - this way we can start integrating that the app knows the signupID for PCP download. This is for a further project down the line but integrating this now with the orb will make things easier
* add specific error for static sessions where the orb does not receieve the response