### PR TITLE
fix(relay-client): missing http2 keepalive

### DIFF
--- a/relay-client/src/actor.rs
+++ b/relay-client/src/actor.rs
@@ -9,7 +9,7 @@ use orb_relay_messages::relay::{
     Entity, RelayConnectRequest, RelayConnectResponse, RelayPayload,
 };
 use secrecy::ExposeSecret;
-use std::collections::HashMap;
+use std::{collections::HashMap, time::Duration};
 use tokio::{task, time};
 use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
@@ -382,8 +382,10 @@ async fn connect(
         ..
     } = opts;
 
-    let mut endpoint =
-        Endpoint::from_shared(domain.clone())?.keep_alive_while_idle(true);
+    let mut endpoint = Endpoint::from_shared(domain.clone())?
+        .keep_alive_while_idle(true)
+        .http2_keep_alive_interval(Duration::from_secs(30))
+        .keep_alive_timeout(Duration::from_secs(10));
 
     if domain.starts_with("https://") {
         let tls_config = ClientTlsConfig::new().with_native_roots();


### PR DESCRIPTION
## fixes
- lack of http2 keepalive was causing relay-clients to get stuck due to relying on tcp retransmission to determine whether connection was lost

## todo
- [x] test on an orb