### PR TITLE
Add is_test flag to announceAppId

### DIFF
--- a/proto/common/v1/orb.proto
+++ b/proto/common/v1/orb.proto
@@ -73,4 +73,5 @@ message AnnounceAppId {
   AppAuthenticatedData app_data = 3;
   AppointmentMetadata appointment_metadata = 4;
   string bypass_age_verification_token = 5;
+  bool is_test = 6;
 }


### PR DESCRIPTION
### Notes
* For the operator mock signup demo - we need the orb to be able to respect a test signup. In this case it would not upload the PCP