### PR TITLE
feat(relay-client): allow triggering reconnection manually

### DIFF
--- a/relay-client/src/lib.rs
+++ b/relay-client/src/lib.rs
@@ -169,6 +169,7 @@ impl RecvMessage {
 #[derive(From, Debug)]
 pub enum Err {
     StopRequest,
+    ReconnectRequest,
     StreamEnded,
     Channel(flume::RecvError),
     Transport(transport::Error),
@@ -313,6 +314,22 @@ impl Client {
         self.actor_tx
             .send(actor::Msg::Stop)
             .wrap_err("actor_tx failed to send Stop message")?;
+
+        Ok(())
+    }
+
+    /// Forces the client to reconnect.
+    ///
+    /// # Example
+    /// ```ignore
+    /// let (client, handle) = Client::connect(opts);
+    ///
+    /// client.reconnect().await?;
+    /// ```
+    pub async fn reconnect(&self) -> Result<(), Err> {
+        self.actor_tx
+            .send(actor::Msg::Reconnect)
+            .wrap_err("actor_tx failed to send Reconnect message")?;
 
         Ok(())
     }

--- a/relay-client/tests/stops.rs
+++ b/relay-client/tests/stops.rs
@@ -1,4 +1,4 @@
-use orb_relay_client::{Amount, Auth, Client, ClientOpts, Err, SendMessage};
+use orb_relay_client::{Amount, Auth, Client, ClientOpts, SendMessage};
 use orb_relay_messages::relay::{
     entity::EntityType, relay_connect_request::Msg, ConnectRequest, ConnectResponse,
 };
@@ -55,7 +55,7 @@ async fn it_stops_sever_when_stop_is_called() {
     assert_eq!(*sv.state().await, 1);
     let stop_fut = async {
         match handle.await {
-            Ok(Err(Err::StopRequest)) => (),
+            Ok(Ok(())) => (),
             other => panic!("unexpected terminatin of client handle: {other:?}"),
         }
     };


### PR DESCRIPTION
will be useful for jobs agent when switching networks