### PR TITLE
Add OrbBusy message for rejecting app requests

### DIFF
--- a/proto/self_serve/orb/v1/orb.proto
+++ b/proto/self_serve/orb/v1/orb.proto
@@ -15,6 +15,7 @@ message W {
     AppointmentFailure appointment_failure = 7;
     AppointmentTimeout appointment_timeout = 8;
     UserDataFailure user_data_failure = 9;
+    OrbBusy orb_busy = 10;
   }
 }
 
@@ -82,6 +83,8 @@ message SignupEnded {
   repeated FailureFeedbackType failure_feedback = 2;
 }
 message AgeVerificationRequiredFromOperator {}
+
+message OrbBusy {}
 
 message PreflightCheck {
   enum Status {


### PR DESCRIPTION
* Adds OrbBusy message that orbs can send to apps when they are already performing an operation and cannot handle a new request
* This is for the new scan QR code logic - it allows for orbs to send rejection messages if they are in use