### PR TITLE
Add subscriber_count to Ack in relay.proto

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# orb-relay-messages
+
+## Pre-push checklist
+
+Always run formatting before pushing:
+
+```sh
+cargo fmt --all
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,1 @@
-# orb-relay-messages
-
-## Pre-push checklist
-
-Always run formatting before pushing:
-
-```sh
-cargo fmt --all
-```
+AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+# orb-relay-messages
+
+## Pre-push checklist
+
+Always run formatting before pushing:
+
+```sh
+cargo fmt --all
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,9 +199,9 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"

--- a/proto/relay.proto
+++ b/proto/relay.proto
@@ -28,15 +28,9 @@ message Heartbeat {
   uint64 seq = 1;
 }
 
-enum DeliveryStatus {
-  DELIVERY_STATUS_UNKNOWN = 0;
-  DELIVERY_STATUS_DELIVERED = 1;
-  DELIVERY_STATUS_NO_SUBSCRIBER = 2;
-}
-
 message Ack {
   uint64 seq = 1;
-  DeliveryStatus delivery_status = 2;
+  optional uint32 subscriber_count = 2;
 }
 
 message Entity {

--- a/proto/relay.proto
+++ b/proto/relay.proto
@@ -28,8 +28,15 @@ message Heartbeat {
   uint64 seq = 1;
 }
 
+enum DeliveryStatus {
+  DELIVERY_STATUS_UNKNOWN = 0;
+  DELIVERY_STATUS_DELIVERED = 1;
+  DELIVERY_STATUS_NO_SUBSCRIBER = 2;
+}
+
 message Ack {
   uint64 seq = 1;
+  DeliveryStatus delivery_status = 2;
 }
 
 message Entity {

--- a/relay-client/src/actor.rs
+++ b/relay-client/src/actor.rs
@@ -195,7 +195,7 @@ fn handle_msg(
             handle_payload(state, recv_msg, seq, &props.client_tx)?;
         }
 
-        Msg::RelayResponse(relay_connect_response::Msg::Ack(Ack { seq })) => {
+        Msg::RelayResponse(relay_connect_response::Msg::Ack(Ack { seq, .. })) => {
             handle_ack(state, seq)
         }
 

--- a/relay-client/tests/send.rs
+++ b/relay-client/tests/send.rs
@@ -116,7 +116,7 @@ async fn sends_at_least_once_retrying_until_ack_is_received() {
             state.push(conn_req.clone());
 
             if state.len() >= max_attempts {
-                Ack { seq }.into_res()
+                Ack { seq, ..Default::default() }.into_res()
             } else {
                 None
             }

--- a/relay-client/tests/send.rs
+++ b/relay-client/tests/send.rs
@@ -116,7 +116,11 @@ async fn sends_at_least_once_retrying_until_ack_is_received() {
             state.push(conn_req.clone());
 
             if state.len() >= max_attempts {
-                Ack { seq, ..Default::default() }.into_res()
+                Ack {
+                    seq,
+                    ..Default::default()
+                }
+                .into_res()
             } else {
                 None
             }


### PR DESCRIPTION
## Summary

When a client sends a message to an offline recipient, the relay accepts it (fire-and-forget via Redis PUBLISH) but the sender gets a bare Ack { seq } with no delivery information. This adds an optional uint32 subscriber_count field to the Ack message so clients know how many subscribers received the message.

### Proto change

```protobuf
message Ack {
  uint64 seq = 1;
  optional uint32 subscriber_count = 2;
}
```

The relay server already gets the subscriber count back from Redis PUBLISH. It just needs to forward it.

### Why optional uint32 instead of an enum

- Clients get strictly more information — the raw count, not a lossy mapping
- optional distinguishes "no info" (None) from "zero subscribers" (Some(0)):
  - None → heartbeat ack or legacy server, no delivery info
  - Some(0) → no active subscribers at publish time
  - Some(n) → n subscribers received the message
- Backward compatible: existing clients that only read seq are unaffected

### Other changes

- Update bytes 1.10.1 → 1.11.1 to fix RUSTSEC-2026-0007
- Add project CLAUDE.md