### PR TITLE
feat: Add P2P node info and PCP blob transfer messages

### DIFF
--- a/proto/common/v1/orb.proto
+++ b/proto/common/v1/orb.proto
@@ -17,6 +17,15 @@ message Heartbeat {
   uint64 seq = 1;
 }
 message NoState {}
+// iroh P2P node addressing information for direct phone-orb connectivity.
+// Exchanged inside AnnounceOrbId / AnnounceAppId so both sides can establish
+// a direct QUIC connection without going through the relay service.
+message P2pNodeInfo {
+  string node_id = 1;                    // iroh EndpointId, base32 encoded
+  repeated string direct_addresses = 2;  // "IP:PORT" socket address strings
+  string relay_url = 3;                  // iroh relay URL for NAT traversal
+}
+
 message AnnounceOrbId {
   enum ModeType {
     MODE_TYPE_UNSPECIFIED = 0;
@@ -48,6 +57,7 @@ message AnnounceOrbId {
   uint64 protocol_version = 8;
   string signup_id = 9;
   string signup_id_pin = 10;
+  P2pNodeInfo p2p_node_info = 11;
 }
 
 // Appointment metadata for verification purposes
@@ -74,4 +84,5 @@ message AnnounceAppId {
   AppointmentMetadata appointment_metadata = 4;
   string bypass_age_verification_token = 5;
   bool is_test = 6;
+  P2pNodeInfo p2p_node_info = 7;
 }

--- a/proto/common/v1/orb.proto
+++ b/proto/common/v1/orb.proto
@@ -16,14 +16,16 @@ message W {
 message Heartbeat {
   uint64 seq = 1;
 }
+
 message NoState {}
+
 // iroh P2P node addressing information for direct phone-orb connectivity.
 // Exchanged inside AnnounceOrbId / AnnounceAppId so both sides can establish
 // a direct QUIC connection without going through the relay service.
 message P2pNodeInfo {
-  string node_id = 1;                    // iroh EndpointId, base32 encoded
-  repeated string direct_addresses = 2;  // "IP:PORT" socket address strings
-  string relay_url = 3;                  // iroh relay URL for NAT traversal
+  string node_id = 1; // iroh EndpointId, base32 encoded
+  repeated string direct_addresses = 2; // "IP:PORT" socket address strings
+  string relay_url = 3; // iroh relay URL for NAT traversal
 }
 
 message AnnounceOrbId {

--- a/proto/self_serve/app/v1/app.proto
+++ b/proto/self_serve/app/v1/app.proto
@@ -10,6 +10,7 @@ message W {
     RequestState request_state = 2;
     AbortSignup abort_signup = 3;
     PairingRequest pairing_request = 4;
+    PcpBlobTransferComplete pcp_blob_transfer_complete = 5;
   }
 }
 
@@ -20,4 +21,11 @@ message PairingRequest {
   string app_id = 1;
   bytes user_data_hash = 2;
   string public_key = 3;
+}
+
+message PcpBlobTransferComplete {
+  string signup_id = 1;
+  uint32 tier = 2;
+  bool success = 3;
+  string error = 4;
 }

--- a/proto/self_serve/orb/v1/orb.proto
+++ b/proto/self_serve/orb/v1/orb.proto
@@ -16,6 +16,7 @@ message W {
     AppointmentTimeout appointment_timeout = 8;
     UserDataFailure user_data_failure = 9;
     OrbBusy orb_busy = 10;
+    PcpBlobReady pcp_blob_ready = 11;
   }
 }
 
@@ -86,6 +87,13 @@ message SignupEnded {
 message AgeVerificationRequiredFromOperator {}
 
 message OrbBusy {}
+
+message PcpBlobReady {
+  string blob_ticket = 1;
+  string signup_id = 2;
+  uint32 tier = 3;
+  uint64 size_bytes = 4;
+}
 
 message PreflightCheck {
   enum Status {


### PR DESCRIPTION
🔗 Add P2P node info and PCP blob transfer messages

Enable direct orb↔phone connectivity by extending the existing protobuf message set with the fields and messages needed for iroh-based P2P communication and PCP blob transfer.

  ## 📋 Changes

  ### 🆕 `common/v1/orb.proto`
  - Add `P2pNodeInfo` message (`node_id`, `direct_addresses`, `relay_url`)
  - Embed `P2pNodeInfo` in `AnnounceOrbId` (field 11) — orb advertises its iroh endpoint
  - Embed `P2pNodeInfo` in `AnnounceAppId` (field 11) — phone advertises its iroh endpoint

  ### 🆕 `self_serve/orb/v1/orb.proto`
  - Add `PcpBlobReady` message: `blob_ticket`, `signup_id`, `tier`, `size_bytes`
  - Add to `W` oneof (field 11) — orb → phone iroh blob ticket delivery

  ### 🆕 `self_serve/app/v1/app.proto`
  - Add `PcpBlobTransferComplete` message: `signup_id`, `tier`, `success`, `error`
  - Add to `W` oneof (field 5) — phone → orb ack/nack per tier

  ## Test plan
  - [x] Proto compiles without errors (Rust + Swift via `process-proto-files.sh`)
  - [x] `P2pNodeInfo` serialises/deserialises correctly through `AnnounceOrbId` and `AnnounceAppId`
  - [x] `PcpBlobReady` and `PcpBlobTransferComplete` round-trip through their respective `W` oneofs
  - [x] Field numbers don't conflict with existing `W` fields