### PR TITLE
Reject empty hash in AppAuthenticatedData::verify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,9 +1124,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.7"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10b3f4191e8a80e6b43eebabfac91e5dcecebb27a71f04e820c47ec41d314bf"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/deny.toml
+++ b/deny.toml
@@ -4,6 +4,9 @@ all-features = true
 
 [sources]
 unknown-registry = "deny"
+allow-git = [
+    "https://github.com/worldcoin/orb-software.git",
+]
 
 [licenses]
 version = 2

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -47,6 +47,9 @@ pub mod common {
             /// `hash` and checks if both hashes are identical.
             pub fn verify(&self, hash: impl AsRef<[u8]>) -> bool {
                 let external_hash = hash.as_ref();
+                if external_hash.is_empty() {
+                    return false;
+                }
                 let internal_hash = self.hash(external_hash.len());
                 external_hash == internal_hash
             }
@@ -103,5 +106,74 @@ pub mod config {
 pub mod jobs {
     pub mod v1 {
         tonic::include_proto!("jobs.v1");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::common::v1::AppAuthenticatedData;
+
+    fn sample_data() -> AppAuthenticatedData {
+        AppAuthenticatedData {
+            self_custody_public_key: "pk_abc123".into(),
+            identity_commitment: "ic_def456".into(),
+            os: "iOS".into(),
+            os_version: "18.0".into(),
+            pcp_version: 2,
+        }
+    }
+
+    #[test]
+    fn verify_rejects_empty_hash() {
+        let data = sample_data();
+        assert!(!data.verify(b""), "empty hash must not verify");
+        assert!(!data.verify(Vec::<u8>::new()), "empty vec must not verify");
+    }
+
+    #[test]
+    fn verify_accepts_correct_hash() {
+        let data = sample_data();
+        let hash = data.hash(32);
+        assert!(data.verify(&hash));
+    }
+
+    #[test]
+    fn verify_rejects_wrong_hash() {
+        let data = sample_data();
+        let mut hash = data.hash(32);
+        hash[0] ^= 0xff;
+        assert!(!data.verify(&hash));
+    }
+
+    #[test]
+    fn verify_accepts_shorter_hash_due_to_xof_prefix_consistency() {
+        // BLAKE3 XOF is prefix-consistent: first N bytes of hash(M) == hash(N) for N < M
+        let data = sample_data();
+        let hash = data.hash(32);
+        assert!(data.verify(&hash[..16]));
+    }
+
+    #[test]
+    fn hash_length_matches_requested() {
+        let data = sample_data();
+        for n in [1, 16, 32, 64] {
+            assert_eq!(data.hash(n).len(), n);
+        }
+    }
+
+    #[test]
+    fn different_data_produces_different_hash() {
+        let data1 = sample_data();
+        let mut data2 = sample_data();
+        data2.identity_commitment = "ic_different".into();
+        assert_ne!(data1.hash(32), data2.hash(32));
+    }
+
+    #[test]
+    fn pcp_version_affects_hash_when_non_default() {
+        let data_default = sample_data(); // pcp_version = 2 (default)
+        let mut data_v3 = sample_data();
+        data_v3.pcp_version = 3;
+        assert_ne!(data_default.hash(32), data_v3.hash(32));
     }
 }


### PR DESCRIPTION
## Summary
- `AppAuthenticatedData::verify()` previously returned `true` for empty hashes because BLAKE3 produces a zero-length output that trivially matches an empty input
- Add early return for empty hash input
- Add unit tests covering verify/hash behavior (empty, correct, wrong, XOF prefix consistency, length, field sensitivity)

Slack thread: https://tfh.slack.com/archives/C086654S528/p1774913812050699