### PR TITLE
Add Namespace enum to relay.proto

### DIFF
--- a/proto/relay.proto
+++ b/proto/relay.proto
@@ -35,7 +35,7 @@ message Ack {
 
 enum Namespace {
   NAMESPACE_UNSPECIFIED = 0;
-  NAMESPACE_WORLD_PAIRING = 1;
+  NAMESPACE_TFH_PAIRING = 1;
 }
 
 message Entity {
@@ -48,7 +48,8 @@ message Entity {
 
   string id = 1;
   EntityType entity_type = 2;
-  string namespace = 3;
+  string namespace = 3; // deprecated: use namespace_type instead
+  Namespace namespace_type = 4;
 }
 
 message ConnectRequest {

--- a/proto/relay.proto
+++ b/proto/relay.proto
@@ -33,6 +33,11 @@ message Ack {
   optional uint32 subscriber_count = 2;
 }
 
+enum Namespace {
+  NAMESPACE_UNSPECIFIED = 0;
+  NAMESPACE_WORLD_PAIRING = 1;
+}
+
 message Entity {
   enum EntityType {
     ENTITY_TYPE_UNSPECIFIED = 0;

--- a/relay-client/src/actor.rs
+++ b/relay-client/src/actor.rs
@@ -435,6 +435,7 @@ async fn connect(
                     id: client_id.clone(),
                     entity_type: *entity_type as i32,
                     namespace: namespace.clone(),
+                    ..Default::default()
                 }),
                 auth_method: Some(match auth {
                     Auth::Token(t) => AuthMethod::Token(t.expose_secret().to_string()),

--- a/relay-client/src/lib.rs
+++ b/relay-client/src/lib.rs
@@ -119,11 +119,13 @@ impl RecvMessage {
                 id: self.client.opts.client_id.clone(),
                 entity_type: self.client.opts.entity_type as i32,
                 namespace: self.client.opts.namespace.clone(),
+                ..Default::default()
             }),
             dst: Some(Entity {
                 id: self.from.id.clone(),
                 entity_type: self.from.entity_type,
                 namespace: self.from.namespace.clone(),
+                ..Default::default()
             }),
             seq: self.seq,
             payload: Some(Any {
@@ -461,11 +463,13 @@ pub(crate) fn relay_payload(
             id: opts.client_id.clone(),
             entity_type: opts.entity_type as i32,
             namespace: opts.namespace.clone(),
+            ..Default::default()
         }),
         dst: Some(Entity {
             id: msg.target_id.clone(),
             entity_type: msg.target_type as i32,
             namespace: msg.target_namespace.clone(),
+            ..Default::default()
         }),
         seq,
         payload: Some(Any {

--- a/relay-client/tests/ask.rs
+++ b/relay-client/tests/ask.rs
@@ -79,11 +79,13 @@ async fn asks_at_most_once() {
             id: "apple".to_string(),
             entity_type: EntityType::App as i32,
             namespace: "green".to_string(),
+            ..Default::default()
         }),
         dst: Some(Entity {
             id: "banana".to_string(),
             entity_type: EntityType::Orb as i32,
             namespace: "yellow".to_string(),
+            ..Default::default()
         }),
         seq: 0,
         payload: Some(Any {
@@ -163,11 +165,13 @@ async fn ask_sends_at_least_once_retrying_until_reply_is_received() {
             id: "papaya".to_string(),
             entity_type: EntityType::App as i32,
             namespace: "orange".to_string(),
+            ..Default::default()
         }),
         dst: Some(Entity {
             id: "blueberry".to_string(),
             entity_type: EntityType::Orb as i32,
             namespace: "purple".to_string(),
+            ..Default::default()
         }),
         seq: 0,
         payload: Some(Any {
@@ -252,11 +256,13 @@ async fn ask_increases_seq() {
                 id: "apple".to_string(),
                 entity_type: EntityType::App as i32,
                 namespace: "green".to_string(),
+                ..Default::default()
             }),
             dst: Some(Entity {
                 id: "banana".to_string(),
                 entity_type: EntityType::Orb as i32,
                 namespace: "yellow".to_string(),
+                ..Default::default()
             }),
             seq,
             payload: Some(Any {

--- a/relay-client/tests/send.rs
+++ b/relay-client/tests/send.rs
@@ -68,12 +68,14 @@ async fn sends_at_most_once_and_increases_seq() {
         id: "foo".to_string(),
         entity_type: EntityType::App as i32,
         namespace: "bar".to_string(),
+        ..Default::default()
     });
 
     let dst = Some(Entity {
         id: "thomas".to_string(),
         entity_type: EntityType::Orb as i32,
         namespace: "anderson".to_string(),
+        ..Default::default()
     });
 
     let expected = [
@@ -161,11 +163,13 @@ async fn sends_at_least_once_retrying_until_ack_is_received() {
             id: "foo".to_string(),
             entity_type: EntityType::App as i32,
             namespace: "bar".to_string(),
+            ..Default::default()
         }),
         dst: Some(Entity {
             id: "thomas".to_string(),
             entity_type: EntityType::Orb as i32,
             namespace: "anderson".to_string(),
+            ..Default::default()
         }),
         seq: 0,
         payload: Some(Any {


### PR DESCRIPTION
## Summary
- Adds a `Namespace` enum to `relay.proto` with `NAMESPACE_WORLD_PAIRING` as the first value
- Gives all consumers (Rust, Kotlin, Swift) a shared, codegen'd source of truth for namespace strings instead of hardcoded magic strings across repos
- The `Entity.namespace` field remains a `string` on the wire — consumers use the generated enum's string name (e.g. `as_str_name()` in Rust) as the value