### PR TITLE
feat: self-describing hash for AppAuthenticatedData

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -39,11 +39,31 @@ pub mod common {
         /// Default PCP version value (proto3 default for uint32)
         const PCP_VERSION_DEFAULT: u32 = 2;
 
+        /// Version prefix for self-describing hash format (v5).
+        const HASH_VERSION_V5: u8 = 0x05;
+
         impl AppAuthenticatedData {
-            /// Returns `true` if `hash` matches this [`AppAuthenticatedData`]
-            /// using length-prefixed BLAKE3 hashing.
+            /// Returns `true` if `hash` matches this [`AppAuthenticatedData`].
             ///
-            /// Use this for QR v5+ verification.
+            /// Dispatches based on the hash format:
+            /// - `0x05` prefix → v5 (length-prefixed BLAKE3)
+            /// - no recognized prefix → v4 legacy (plain BLAKE3)
+            pub fn verify(&self, hash: impl AsRef<[u8]>) -> bool {
+                let hash = hash.as_ref();
+                if hash.is_empty() {
+                    return false;
+                }
+                if hash.first() == Some(&HASH_VERSION_V5) {
+                    self.verify_with_length_prefix(&hash[1..])
+                } else {
+                    self.verify_legacy(hash)
+                }
+            }
+
+            /// Returns `true` if `hash` matches using length-prefixed BLAKE3.
+            ///
+            /// Prefer [`Self::verify()`] which handles version dispatch
+            /// automatically.
             pub fn verify_with_length_prefix(&self, hash: impl AsRef<[u8]>) -> bool {
                 let external_hash = hash.as_ref();
                 if external_hash.is_empty() {
@@ -53,17 +73,29 @@ pub mod common {
                 external_hash == internal_hash
             }
 
-            /// Returns `true` if `hash` matches this [`AppAuthenticatedData`]
-            /// using the legacy (unfixed) hashing.
+            /// Returns `true` if `hash` matches using legacy (unfixed) hashing.
             ///
-            /// Use this for QR v4 verification. Do not use for new code.
-            pub fn verify(&self, hash: impl AsRef<[u8]>) -> bool {
+            /// For QR v4 backward compatibility only. Do not use for new code.
+            pub fn verify_legacy(&self, hash: impl AsRef<[u8]>) -> bool {
                 let external_hash = hash.as_ref();
                 if external_hash.is_empty() {
                     return false;
                 }
-                let internal_hash = self.hash(external_hash.len());
+                let internal_hash = self.hash_legacy(external_hash.len());
                 external_hash == internal_hash
+            }
+
+            /// Calculates a self-describing BLAKE3 hash with version prefix.
+            ///
+            /// Returns `0x05 ++ BLAKE3(length-prefixed fields)` where the BLAKE3
+            /// digest is truncated to `truncate_to` bytes. The total output
+            /// length is `truncate_to + 1`.
+            pub fn hash(&self, truncate_to: usize) -> Vec<u8> {
+                let digest = self.hash_with_length_prefix(truncate_to);
+                let mut out = Vec::with_capacity(1 + digest.len());
+                out.push(HASH_VERSION_V5);
+                out.extend_from_slice(&digest);
+                out
             }
 
             /// Calculates a BLAKE3 hash of length `n` with length-prefixed fields,
@@ -91,12 +123,14 @@ pub mod common {
                 output
             }
 
-            /// Calculates a BLAKE3 hash of length `n` using the legacy (unfixed) method.
+            /// Calculates a BLAKE3 hash of length `n` using the legacy (unfixed)
+            /// method.
             ///
-            /// This method concatenates fields without length prefixes, which allows
-            /// hash collisions by shifting bytes between adjacent fields.
-            /// Kept for backward compatibility with QR v4. Do not use for new code.
-            pub fn hash(&self, n: usize) -> Vec<u8> {
+            /// This method concatenates fields without length prefixes, which
+            /// allows hash collisions by shifting bytes between adjacent fields.
+            /// Kept for backward compatibility with QR v4. Do not use for new
+            /// code.
+            pub fn hash_legacy(&self, n: usize) -> Vec<u8> {
                 let mut hasher = Hasher::new();
                 self.hasher_update(&mut hasher);
                 let mut output = vec![0; n];
@@ -161,6 +195,8 @@ mod tests {
         }
     }
 
+    // --- Self-describing verify() dispatcher tests ---
+
     #[test]
     fn verify_rejects_empty_hash() {
         let data = sample_data();
@@ -169,34 +205,59 @@ mod tests {
     }
 
     #[test]
-    fn verify_accepts_correct_hash() {
+    fn verify_accepts_self_describing_hash() {
         let data = sample_data();
         let hash = data.hash(32);
         assert!(data.verify(&hash));
     }
 
     #[test]
-    fn verify_rejects_wrong_hash() {
+    fn verify_accepts_legacy_hash() {
+        let data = sample_data();
+        let hash = data.hash_legacy(32);
+        assert!(data.verify(&hash));
+    }
+
+    #[test]
+    fn verify_rejects_wrong_self_describing_hash() {
         let data = sample_data();
         let mut hash = data.hash(32);
-        hash[0] ^= 0xff;
+        // Corrupt a digest byte (not the version prefix)
+        hash[1] ^= 0xff;
         assert!(!data.verify(&hash));
     }
 
     #[test]
-    fn verify_accepts_shorter_hash_due_to_xof_prefix_consistency() {
-        // BLAKE3 XOF is prefix-consistent: first N bytes of hash(M) == hash(N) for N < M
+    fn verify_rejects_wrong_legacy_hash() {
+        let data = sample_data();
+        let mut hash = data.hash_legacy(32);
+        hash[0] ^= 0xff;
+        assert!(!data.verify(&hash));
+    }
+
+    // --- Self-describing hash() tests ---
+
+    #[test]
+    fn hash_has_version_prefix() {
         let data = sample_data();
         let hash = data.hash(32);
-        assert!(data.verify(&hash[..16]));
+        assert_eq!(hash[0], 0x05, "first byte must be version prefix");
     }
 
     #[test]
-    fn hash_length_matches_requested() {
+    fn hash_length_is_digest_plus_one() {
         let data = sample_data();
         for n in [1, 16, 32, 64] {
-            assert_eq!(data.hash(n).len(), n);
+            assert_eq!(data.hash(n).len(), n + 1);
         }
+    }
+
+    #[test]
+    fn hash_digest_matches_hash_with_length_prefix() {
+        let data = sample_data();
+        let self_describing = data.hash(32);
+        let raw = data.hash_with_length_prefix(32);
+        assert_eq!(&self_describing[1..], &raw[..]);
     }
 
     #[test]
@@ -207,12 +268,55 @@ mod tests {
         assert_ne!(data1.hash(32), data2.hash(32));
     }
 
+    // --- Legacy hash tests ---
+
     #[test]
-    fn pcp_version_affects_hash_when_non_default() {
+    fn legacy_verify_rejects_empty_hash() {
+        let data = sample_data();
+        assert!(!data.verify_legacy(b""), "empty hash must not verify");
+        assert!(
+            !data.verify_legacy(Vec::<u8>::new()),
+            "empty vec must not verify"
+        );
+    }
+
+    #[test]
+    fn legacy_verify_accepts_correct_hash() {
+        let data = sample_data();
+        let hash = data.hash_legacy(32);
+        assert!(data.verify_legacy(&hash));
+    }
+
+    #[test]
+    fn legacy_verify_rejects_wrong_hash() {
+        let data = sample_data();
+        let mut hash = data.hash_legacy(32);
+        hash[0] ^= 0xff;
+        assert!(!data.verify_legacy(&hash));
+    }
+
+    #[test]
+    fn legacy_verify_accepts_shorter_hash_due_to_xof_prefix_consistency() {
+        // BLAKE3 XOF is prefix-consistent: first N bytes of hash(M) == hash(N) for N < M
+        let data = sample_data();
+        let hash = data.hash_legacy(32);
+        assert!(data.verify_legacy(&hash[..16]));
+    }
+
+    #[test]
+    fn legacy_hash_length_matches_requested() {
+        let data = sample_data();
+        for n in [1, 16, 32, 64] {
+            assert_eq!(data.hash_legacy(n).len(), n);
+        }
+    }
+
+    #[test]
+    fn legacy_pcp_version_affects_hash_when_non_default() {
         let data_default = sample_data(); // pcp_version = 2 (default)
         let mut data_v3 = sample_data();
         data_v3.pcp_version = 3;
-        assert_ne!(data_default.hash(32), data_v3.hash(32));
+        assert_ne!(data_default.hash_legacy(32), data_v3.hash_legacy(32));
     }
 
     // --- hash_with_length_prefix tests ---
@@ -241,7 +345,7 @@ mod tests {
     #[test]
     fn length_prefix_hash_differs_from_legacy() {
         let data = sample_data();
-        assert_ne!(data.hash(32), data.hash_with_length_prefix(32));
+        assert_ne!(data.hash_legacy(32), data.hash_with_length_prefix(32));
     }
 
     #[test]
@@ -263,7 +367,7 @@ mod tests {
             pcp_version: 2,
         };
         // Legacy hash: these collide because "abc"+"def" == "ab"+"cdef"
-        assert_eq!(data_a.hash(32), data_b.hash(32));
+        assert_eq!(data_a.hash_legacy(32), data_b.hash_legacy(32));
         // Length-prefixed hash: these do NOT collide
         assert_ne!(
             data_a.hash_with_length_prefix(32),
@@ -287,11 +391,11 @@ mod tests {
     #[test]
     fn legacy_and_length_prefix_are_not_cross_compatible() {
         let data = sample_data();
-        let legacy_hash = data.hash(32);
+        let legacy_hash = data.hash_legacy(32);
         let lp_hash = data.hash_with_length_prefix(32);
         // Legacy hash should not verify with length-prefix verifier
         assert!(!data.verify_with_length_prefix(&legacy_hash));
         // Length-prefix hash should not verify with legacy verifier
-        assert!(!data.verify(&lp_hash));
+        assert!(!data.verify_legacy(&lp_hash));
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -46,18 +46,22 @@ pub mod common {
             /// Returns `true` if `hash` matches this [`AppAuthenticatedData`].
             ///
             /// Dispatches based on the hash format:
-            /// - `0x05` prefix → v5 (length-prefixed BLAKE3)
-            /// - no recognized prefix → v4 legacy (plain BLAKE3)
+            /// - `0x05` prefix → try v5 (length-prefixed BLAKE3) first
+            /// - falls back to v4 legacy (plain BLAKE3)
+            ///
+            /// The fallback handles the case where a legacy hash happens to
+            /// start with `0x05` (~0.4% probability for random BLAKE3 output).
             pub fn verify(&self, hash: impl AsRef<[u8]>) -> bool {
                 let hash = hash.as_ref();
                 if hash.is_empty() {
                     return false;
                 }
-                if hash.first() == Some(&HASH_VERSION_V5) {
-                    self.verify_with_length_prefix(&hash[1..])
-                } else {
-                    self.verify_legacy(hash)
+                if hash.first() == Some(&HASH_VERSION_V5)
+                    && self.verify_with_length_prefix(&hash[1..])
+                {
+                    return true;
                 }
+                self.verify_legacy(hash)
             }
 
             /// Returns `true` if `hash` matches using length-prefixed BLAKE3.
@@ -233,6 +237,26 @@ mod tests {
         let mut hash = data.hash_legacy(32);
         hash[0] ^= 0xff;
         assert!(!data.verify(&hash));
+    }
+
+    #[test]
+    fn verify_accepts_legacy_hash_starting_with_version_byte() {
+        // ~0.4% of legacy hashes start with 0x05 by chance. The dispatcher
+        // tries v5 first (which fails), then falls back to legacy.
+        // Brute-force an input whose legacy hash starts with 0x05.
+        let data = (0u32..)
+            .map(|i| AppAuthenticatedData {
+                identity_commitment: format!("ic_{i}"),
+                ..sample_data()
+            })
+            .find(|d| d.hash_legacy(32)[0] == 0x05)
+            .expect("should find a collision within a few hundred tries");
+        let hash = data.hash_legacy(32);
+        assert_eq!(hash[0], 0x05);
+        assert!(
+            data.verify(&hash),
+            "legacy hash starting with 0x05 must still verify"
+        );
     }
 
     // --- Self-describing hash() tests ---

--- a/rust/tests/app_authenticated_data_verification.rs
+++ b/rust/tests/app_authenticated_data_verification.rs
@@ -16,7 +16,7 @@ MCowBQYDK2VuAyEA2boNBmJX4lGkA9kjthS5crXOBxu2BPycKRMakpzgLG4=
         os: "Android".to_string(),
         os_version: "1.2.3".to_string(),
     };
-    let hash_app_data = app_data.hash(16);
+    let hash_app_data = app_data.hash_legacy(16);
     let qr = encode_static_qr(&orb_relay_id, hash_app_data);
     let (version, parsed_orb_relay_id, parsed_app_data) =
         decode_qr_with_version(&qr).unwrap();
@@ -39,7 +39,7 @@ MCowBQYDK2VuAyEA2boNBmJX4lGkA9kjthS5crXOBxu2BPycKRMakpzgLG4=
         os: "Android".to_string(),
         os_version: "1.2.3".to_string(),
     };
-    let hash_app_data = app_data.hash(16);
+    let hash_app_data = app_data.hash_legacy(16);
     let qr = encode_static_qr(&orb_relay_id, hash_app_data);
     let (version, parsed_orb_relay_id, parsed_app_data) =
         decode_qr_with_version(&qr).unwrap();


### PR DESCRIPTION
## Summary

- `hash()` now returns a self-describing hash: `0x05 ++ BLAKE3(length-prefixed fields)`. The version byte travels with the hash, not with the data being verified.
- `verify()` dispatches on the first byte: `0x05` → v5 length-prefixed path, anything else → v4 legacy fallback. Both QR scan and relay pairing work with either format.
- Old methods renamed to `hash_legacy()` / `verify_legacy()` for backward compatibility during migration.

### Migration path

1. **Now**: Deploy this. Orb-side `verify()` handles both formats.
2. **Phase 2**: Migrate apps (World App, oxide) from `hash_legacy()` to `hash()`. No orb-side changes needed.
3. **Phase 3**: Remove legacy fallback and `hash_legacy()` / `verify_legacy()`.

### Breaking changes

- `hash()` signature unchanged but now returns `n+1` bytes (1 prefix + n digest) instead of `n`
- `verify()` signature unchanged but now dispatches on prefix instead of always using legacy
- Callers using the old `hash()`/`verify()` for v4 must switch to `hash_legacy()`/`verify_legacy()`