### PR TITLE
Add reason field to AbortSignup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,9 +1176,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/proto/self_serve/app/v1/app.proto
+++ b/proto/self_serve/app/v1/app.proto
@@ -16,7 +16,9 @@ message W {
 
 message StartCapture {}
 message RequestState {}
-message AbortSignup {}
+message AbortSignup {
+  string reason = 1;
+}
 message PairingRequest {
   string app_id = 1;
   bytes user_data_hash = 2;


### PR DESCRIPTION
## Summary

Adds a free-form `string reason` field to `AbortSignup` so the app can communicate why a signup was aborted (e.g. user cancellation, timeout, error).

`AbortSignup` was previously empty, so this is a backwards-compatible addition on the wire.