### PR TITLE
Make AbortSignup reason an enum

### DIFF
--- a/proto/self_serve/app/v1/app.proto
+++ b/proto/self_serve/app/v1/app.proto
@@ -17,7 +17,12 @@ message W {
 message StartCapture {}
 message RequestState {}
 message AbortSignup {
-  string reason = 1;
+  enum Reason {
+    REASON_UNSPECIFIED = 0;
+    REASON_USER_CANCELLED = 1;
+    REASON_HEARTBEAT_TIMEOUT = 2;
+  }
+  Reason reason = 1;
 }
 message PairingRequest {
   string app_id = 1;


### PR DESCRIPTION
## Summary

Replaces the `string reason` field on `AbortSignup` (added in #103) with a nested `Reason` enum. Reuses tag 1 — safe because #103 just merged and no producers/consumers are on the wire yet.

Values: `REASON_UNSPECIFIED`, `REASON_USER_CANCELLED`, `REASON_HEARTBEAT_TIMEOUT`.