### PR TITLE
Add CaptureEnded feedback types and ORB_INTERNAL_ERROR

### DIFF
--- a/proto/self_serve/orb/v1/orb.proto
+++ b/proto/self_serve/orb/v1/orb.proto
@@ -43,10 +43,9 @@ message CaptureTriggerTimeout {}
 message CaptureEnded {
   enum FailureFeedbackType {
     FAILURE_FEEDBACK_TYPE_UNSPECIFIED = 0;
-    // Deprecated: split into FACE_OCCLUSION, LIGHTING_TOO_DARK, and
-    // LIGHTING_TOO_BRIGHT. Kept for clients that have not yet adopted the
-    // split; the orb no longer emits it.
-    FAILURE_FEEDBACK_TYPE_FACE_OCCLUSION_OR_POOR_LIGHTING = 1 [deprecated = true];
+    // To be deprecated: split into FACE_OCCLUSION, LIGHTING_TOO_DARK, and
+    // LIGHTING_TOO_BRIGHT. Kept until clients adopt the split.
+    FAILURE_FEEDBACK_TYPE_FACE_OCCLUSION_OR_POOR_LIGHTING = 1;
     FAILURE_FEEDBACK_TYPE_TOO_FAR = 2;
     FAILURE_FEEDBACK_TYPE_TOO_CLOSE = 3;
     FAILURE_FEEDBACK_TYPE_EYES_OCCLUSION = 4;

--- a/proto/self_serve/orb/v1/orb.proto
+++ b/proto/self_serve/orb/v1/orb.proto
@@ -88,6 +88,7 @@ message SignupEnded {
     FAILURE_FEEDBACK_TYPE_PUPIL2_IRIS_CONSTRICTION = 18;
     FAILURE_FEEDBACK_TYPE_PUPIL2_IRIS_OFFCENTER = 19;
     FAILURE_FEEDBACK_TYPE_IRIS_NOT_CENTERED = 20;
+    // Upload / orb-side failures
     FAILURE_FEEDBACK_TYPE_PCP_UPLOAD_FAILED = 21;
     // Orb-side failure (hardware/network), not the user's fault. Apps render a
     // dedicated orb-error screen rather than the generic failure screen.

--- a/proto/self_serve/orb/v1/orb.proto
+++ b/proto/self_serve/orb/v1/orb.proto
@@ -43,12 +43,23 @@ message CaptureTriggerTimeout {}
 message CaptureEnded {
   enum FailureFeedbackType {
     FAILURE_FEEDBACK_TYPE_UNSPECIFIED = 0;
-    FAILURE_FEEDBACK_TYPE_FACE_OCCLUSION_OR_POOR_LIGHTING = 1;
+    // Deprecated: split into FACE_OCCLUSION, LIGHTING_TOO_DARK, and
+    // LIGHTING_TOO_BRIGHT. Kept for clients that have not yet adopted the
+    // split; the orb no longer emits it.
+    FAILURE_FEEDBACK_TYPE_FACE_OCCLUSION_OR_POOR_LIGHTING = 1 [deprecated = true];
     FAILURE_FEEDBACK_TYPE_TOO_FAR = 2;
     FAILURE_FEEDBACK_TYPE_TOO_CLOSE = 3;
     FAILURE_FEEDBACK_TYPE_EYES_OCCLUSION = 4;
     FAILURE_FEEDBACK_TYPE_USER_ABORT = 5;
     FAILURE_FEEDBACK_TYPE_FACE_NOT_SEEN = 6;
+    FAILURE_FEEDBACK_TYPE_TOO_HIGH = 7;
+    FAILURE_FEEDBACK_TYPE_TOO_LOW = 8;
+    FAILURE_FEEDBACK_TYPE_FACE_OCCLUSION = 9;
+    FAILURE_FEEDBACK_TYPE_LIGHTING_TOO_DARK = 10;
+    FAILURE_FEEDBACK_TYPE_LIGHTING_TOO_BRIGHT = 11;
+    // Orb-side failure (hardware/network), not the user's fault. Apps render a
+    // dedicated orb-error screen rather than the generic failure screen.
+    FAILURE_FEEDBACK_TYPE_ORB_INTERNAL_ERROR = 12;
   }
 
   bool success = 1;
@@ -79,6 +90,9 @@ message SignupEnded {
     FAILURE_FEEDBACK_TYPE_PUPIL2_IRIS_OFFCENTER = 19;
     FAILURE_FEEDBACK_TYPE_IRIS_NOT_CENTERED = 20;
     FAILURE_FEEDBACK_TYPE_PCP_UPLOAD_FAILED = 21;
+    // Orb-side failure (hardware/network), not the user's fault. Apps render a
+    // dedicated orb-error screen rather than the generic failure screen.
+    FAILURE_FEEDBACK_TYPE_ORB_INTERNAL_ERROR = 22;
   }
 
   bool success = 1;


### PR DESCRIPTION
## Motivation

Capture failures collapse occlusion and lighting into one feedback type and never report vertical misalignment, so the app can't give the user actionable guidance. Orb-side failures also lack a dedicated signal (ORBA-486).

Splits `FACE_OCCLUSION_OR_POOR_LIGHTING` (now deprecated, still wire-present) into `FACE_OCCLUSION`, `LIGHTING_TOO_DARK`, `LIGHTING_TOO_BRIGHT`, adds `TOO_HIGH`/`TOO_LOW` to `CaptureEnded`, and adds `ORB_INTERNAL_ERROR` to both `CaptureEnded` and `SignupEnded`. All values are append-only; the deprecated value keeps its number for clients that haven't adopted the split.