### PR TITLE
Derive serde and schemars on FailureFeedbackType enums

### DIFF
--- a/rust/build.rs
+++ b/rust/build.rs
@@ -14,6 +14,16 @@ fn main() {
         .enum_attribute(
             ".self_serve.app.v1.AbortSignup.Reason",
             "#[derive(serde::Serialize, schemars::JsonSchema)]",
+        )
+        .enum_attribute(
+            ".self_serve.orb.v1.CaptureEnded.FailureFeedbackType",
+            "#[derive(serde::Serialize, schemars::JsonSchema)]\n\
+             #[schemars(rename = \"CaptureFailureFeedbackType\")]",
+        )
+        .enum_attribute(
+            ".self_serve.orb.v1.SignupEnded.FailureFeedbackType",
+            "#[derive(serde::Serialize, schemars::JsonSchema)]\n\
+             #[schemars(rename = \"SignupFailureFeedbackType\")]",
         );
     tonic_prost_build::configure()
         .build_client(cfg!(feature = "client"))


### PR DESCRIPTION
## Motivation

orb-core embeds capture and signup failure feedback in its debug report, whose JSON schema is consumed by legal review and must enumerate the possible values. Without derives on the generated enums, orb-core has to maintain hand-written mirror copies.

Adds the same `serde::Serialize` + `schemars::JsonSchema` `enum_attribute` already used for `AbortSignup.Reason` to the two `FailureFeedbackType` enums.